### PR TITLE
revert(go-version): revert go version to 1.22 for cosmtrek/air compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.breu.io/quantm
 
-go 1.23
+go 1.22
 
 require (
 	cloud.google.com/go/logging v1.11.0


### PR DESCRIPTION
- revert(go-version): revert the go version from 1.23 to 1.22 due to cosmtrek/air not support 1.23