### PR TITLE
chore(erratic): improve error handling capabilities

### DIFF
--- a/internal/erratic/hints.go
+++ b/internal/erratic/hints.go
@@ -6,16 +6,21 @@ type (
 	// Example:
 	//
 	//  info := Hints{"field": "invalid value"}
-	//  fmt.Println(info) // Output: map[string]string{"field": "invalid value"}
-	Hints map[string]string
+	//  fmt.Println(info) // Output: map[string]any{"field": "invalid value"}
+	Hints map[string]any
 )
 
 func NewHints(args ...string) Hints {
 	odd := len(args)%2 != 0
 
+	limit := len(args)
+	if odd {
+		limit--
+	}
+
 	details := make(Hints)
 
-	for i := 0; i < len(args); i += 2 {
+	for i := 0; i < limit; i += 2 {
 		details[args[i]] = args[i+1]
 	}
 

--- a/internal/erratic/quantm_test.go
+++ b/internal/erratic/quantm_test.go
@@ -1,0 +1,56 @@
+package erratic_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.breu.io/quantm/internal/erratic"
+)
+
+func TestQuantmError_Hints(t *testing.T) {
+	// Test adding various types of hints
+	err := erratic.NewBadRequestError(erratic.CommonModule, "test error").
+		AddHint("string_key", "string_value").
+		AddHint("int_key", 123).
+		AddHint("bool_key", true).
+		AddHint("map_key", map[string]string{"foo": "bar"})
+
+	// Verify LogValue
+
+	lv := err.LogValue()
+	assert.Equal(t, slog.KindGroup, lv.Kind())
+
+	// Verify ToProto (should stringify hints)
+	protoStatus := err.ToProto()
+	require.NotNil(t, protoStatus)
+
+	// Verify ToConnectError (should stringify hints)
+	connectErr := err.ToConnectError()
+	require.NotNil(t, connectErr)
+	assert.Equal(t, "string_value", connectErr.Meta().Get("string_key"))
+	assert.Equal(t, "123", connectErr.Meta().Get("int_key"))
+	assert.Equal(t, "true", connectErr.Meta().Get("bool_key"))
+}
+
+func TestQuantmError_StackHint(t *testing.T) {
+	err := erratic.New(erratic.CommonModule, erratic.CodeSystem, "system error")
+
+	// Add manual stack hint
+
+	_ = err.WithStack("fake stack trace")
+
+	// Should not panic in ToProto due to type assertion
+
+	protoStatus := err.ToProto()
+	require.NotNil(t, protoStatus)
+}
+
+func TestQuantmError_New(t *testing.T) {
+	// Just verify New creates an error without panic
+	err := erratic.New(erratic.CommonModule, erratic.CodeUnknown, "unknown")
+	assert.NotNil(t, err)
+	assert.Equal(t, "unknown", err.Message)
+}


### PR DESCRIPTION
Several key improvements to the `erratic` package:

- **Stack Trace Capture:** The `New` function now automatically captures the stack frame where the error is created, providing valuable debugging information.
- **Slog Integration:** Implemented `slog.LogValuer` for `QuantmError`, allowing for structured logging of error details.
- **Hint Type Flexibility:** The `Hints` type in `internal/erratic/hints.go` has been changed from `map[string]string` to `map[string]any`, enabling the storage of non-string values as hints.
- **Proto/Connect Error Stringification:** When converting errors to proto or Connect errors, hints are now stringified to ensure compatibility.
- **New Test Cases:** Added comprehensive unit tests for the `QuantmError` type, covering hint handling, stack trace scenarios, and the `New` function.